### PR TITLE
Add backend launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
+## JSON backend
+
+The sample charts expect a small JSON-serving API running on port `3000`.  You can
+start either the Node or Python version of this backend from the `server`
+directory:
+
+```bash
+# Node implementation
+node server.js
+
+# Python (FastAPI) implementation
+uvicorn server:app --reload
+```
+
+Both commands launch the API at `http://localhost:3000`.
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.


### PR DESCRIPTION
## Summary
- document how to launch the JSON backend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68415bcf413883209358d333902a3a75