### PR TITLE
Standardize to camelCase

### DIFF
--- a/src/app/components/benchmark-bubble3/benchmark-bubble3.component.ts
+++ b/src/app/components/benchmark-bubble3/benchmark-bubble3.component.ts
@@ -122,7 +122,7 @@ export class BenchmarkBubble3Component implements OnInit {
       //=====================================================================================
       // Assign the data of the sphericity plot
       //=====================================================================================
-      const {data: plotData, layout: plotLayout} = this.dataService.get_bubble_sphericity_3d(
+      const {data: plotData, layout: plotLayout} = this.dataService.getBubbleSphericity3d(
         this.data[0],
         this.data[1],
         this.data[2],
@@ -132,7 +132,7 @@ export class BenchmarkBubble3Component implements OnInit {
       //=====================================================================================
       // Assign the data of the mass conservation plot
       //=====================================================================================
-      const {data: massData, layout: massLayout} = this.dataService.get_bubble_mass_3d(
+      const {data: massData, layout: massLayout} = this.dataService.getBubbleMass3d(
         this.data[3],
         this.data[4],
         this.data[5]
@@ -143,7 +143,7 @@ export class BenchmarkBubble3Component implements OnInit {
       //=====================================================================================
       // Assign the data of the size plot
       //=====================================================================================
-      const {data: sizeData, layout: sizeLayout} = this.dataService.get_bubble_size_3d(
+      const {data: sizeData, layout: sizeLayout} = this.dataService.getBubbleSize3d(
         this.data[6],
         this.data[7],
         this.data[8]
@@ -154,7 +154,7 @@ export class BenchmarkBubble3Component implements OnInit {
       //=====================================================================================
       // Assign the data of the surface plot
       //=====================================================================================
-      const {data: surfaceData, layout: surfaceLayout} = this.dataService.get_bubble_surface_3d(
+      const {data: surfaceData, layout: surfaceLayout} = this.dataService.getBubbleSurface3d(
         this.data[9],
         this.data[10],
         this.data[11]

--- a/src/app/services/benchmark-plot.service.ts
+++ b/src/app/services/benchmark-plot.service.ts
@@ -291,17 +291,17 @@ export class BenchmarkPlotService {
     return { data: bubbleMass_data, layout: bubbleMass_Layout };
   }
 
-  private processData(dataFile: any, style?: string, s_max: number = 2) {
+  private processData(dataFile: any, style?: string, sMax: number = 2) {
     let nSegments = dataFile.x.length / 2;
     const plotData = [];
 
-    if (s_max !== undefined) {
-      nSegments = dataFile.x.length / s_max;
+    if (sMax !== undefined) {
+      nSegments = dataFile.x.length / sMax;
     }
 
     for (let i = 0; i < nSegments; i++) {
-      const segmentX = dataFile.x.slice(s_max * i, s_max * (i + 1));
-      const segmentY = dataFile.y.slice(s_max * i, s_max * (i + 1));
+      const segmentX = dataFile.x.slice(sMax * i, sMax * (i + 1));
+      const segmentY = dataFile.y.slice(sMax * i, sMax * (i + 1));
 
       if (i === 0) {
         if (style !== undefined) {

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -73,7 +73,7 @@ export class DataService {
   //=====================================================================================
   // Here we have the data of the sphericity plot
   //=====================================================================================
-  get_bubble_sphericity_3d(
+  getBubbleSphericity3d(
     RB3sphericityL1In: PlotData[],
     RB3sphericityL2In: PlotData[],
     RB3sphericityL3In: PlotData[]
@@ -133,7 +133,7 @@ export class DataService {
   //=====================================================================================
   // Here we have the data of the mass conservation plot (Bubble 3D)
   //=====================================================================================
-  get_bubble_mass_3d(
+  getBubbleMass3d(
     RB3bubble_massL1: PlotData[],
     RB3bubble_massL2: PlotData[],
     RB3bubble_massL3: PlotData[]
@@ -189,7 +189,7 @@ export class DataService {
   //=====================================================================================
   // Here we have the data of the size plot
   //=====================================================================================
-  get_bubble_size_3d(
+  getBubbleSize3d(
     RB3sizeL1: PlotData[],
     RB3sizeL2: PlotData[],
     RB3sizeL3: PlotData[]
@@ -244,7 +244,7 @@ export class DataService {
   //=====================================================================================
   // Here we have the data of the surface plot
   //=====================================================================================
-  get_bubble_surface_3d(
+  getBubbleSurface3d(
     RB3surfaceL1: PlotData[],
     RB3surfaceL2: PlotData[],
     RB3surfaceL3: PlotData[]
@@ -330,7 +330,7 @@ export class DataService {
   //=====================================================================================
   // Here we have the data of the circularity (Bubble 2D Case 1)
   //=====================================================================================
-  get_case1_bubble_circularity_2d() {
+  getCase1BubbleCircularity2d() {
 
     const markerTraceTP2D = {
       x: c1g1l1_circularity_data.x.filter((_, index) => index % 90 === 0),
@@ -1263,7 +1263,7 @@ return {
 };
 
 
-  get_case1_bubble_com_2d() {
+  getCase1BubbleCom2d() {
     //const bubble2Shape_data = [bubbleShape];
   
     const markerTraceTP2D = {
@@ -1449,7 +1449,7 @@ return {
     }
   };
 
-  get_case1_bubble_vel_2d() {
+  getCase1BubbleVel2d() {
     //const bubble2Velocity_data = [];
 
     const markerTraceTP2D = {
@@ -1630,7 +1630,7 @@ return {
 
 
   //case 1 bubble shape
-  get_case1_bubble_shape_2d() {
+  getCase1BubbleShape2d() {
 
     const nSegments = c1g1l4s_data.x.length / 2;
     const plotData = [];
@@ -1698,14 +1698,14 @@ return {
     }
   };
 
-  load_case2_bubble_shape_2d() {
+  loadCase2BubbleShape2d() {
 
     let jsonData = "";
 
   }
 
   //case2 bubble shape
-  get_case2_bubble_shape_2d() {
+  getCase2BubbleShape2d() {
 
 //    let jsonData = "";
 //    this.postService.postFileRequest("bubble_shape_case2").subscribe(
@@ -1842,7 +1842,7 @@ return {
     }
   };
 
-  get_case1_bubble_mass_2d() { 
+  getCase1BubbleMass2d() {
     //const bubble2Velocity_data = []; N for normalized
     
     const markerTraceTP2D = {


### PR DESCRIPTION
## Summary
- revert Python helper functions to snake_case
- keep Angular helpers in camelCase

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*
- `python server/test_security.py`


------
https://chatgpt.com/codex/tasks/task_e_684fd2b6c30083208638c5b3e0c1990b