### PR TITLE
Add images to particle sedimentation results

### DIFF
--- a/src/app/components/benchmark-particle-sedimentation/benchmark-particle-sedimentation.component.html
+++ b/src/app/components/benchmark-particle-sedimentation/benchmark-particle-sedimentation.component.html
@@ -134,6 +134,11 @@
     can be compared with analytical solutions for the limiting cases.</p>
     </div>
 
+    <div class="results-images">
+      <img src="assets/velocities.png" alt="Particle velocities over time">
+      <img src="assets/positions.png" alt="Particle positions over time">
+    </div>
+
   </mat-tab>
 
   <mat-tab label="Reference Data">

--- a/src/app/components/benchmark-particle-sedimentation/benchmark-particle-sedimentation.component.scss
+++ b/src/app/components/benchmark-particle-sedimentation/benchmark-particle-sedimentation.component.scss
@@ -49,6 +49,31 @@ mat-tab-group {
   flex-direction: row;
 }
 
+.results-images {
+  width: 80%;
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.results-images img {
+  width: 100%;
+  height: auto;
+}
+
+@media screen and (min-width: 1920px) {
+  .results-images {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .results-images img {
+    width: 45%;
+  }
+}
+
 .red {
 flex: 1;
 background-color: red;


### PR DESCRIPTION
## Summary
- add missing images for velocity and position results
- style images responsively with CSS so they appear side-by-side on wide screens

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68779eefcbbc8320a68007fb50b7422b